### PR TITLE
Set English as the only available language

### DIFF
--- a/config/application_custom.rb
+++ b/config/application_custom.rb
@@ -1,6 +1,6 @@
 module Consul
   class Application < Rails::Application
-    config.i18n.available_locales = %w[en fr nl]
+    config.i18n.available_locales = %w[en]
 
     config.autoload_paths << "#{Rails.root}/app/controllers/custom/concerns"
     config.sign_in_links = Rails.env.test?


### PR DESCRIPTION
## Objectives

Set English as the only available language.

## Visual Changes

As the is only one language available the language interface will be hidden.