### PR TITLE
 Allow anonymous users to send their contact information

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -135,3 +135,7 @@ body:not(.admin) {
   margin: 3rem;
   padding: 3rem 1.5rem;
 }
+
+.polls-show .scroll-to-form {
+  margin-top: 1rem;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -128,3 +128,10 @@ body:not(.admin) {
 .calc-comments {
   z-index: 1;
 }
+
+.guest-information-form {
+  border: 6px solid $border;
+  border-radius: 0.75rem;
+  margin: 3rem;
+  padding: 3rem 1.5rem;
+}

--- a/app/components/custom/guest_information/form_component.html.erb
+++ b/app/components/custom/guest_information/form_component.html.erb
@@ -1,0 +1,18 @@
+<div id="guest-information-form" class="guest-information-form row">
+  <div class="small-12 medium-6 medium-offset-3 column">
+    <h2><%= t("guest_information.form.title") %></h2>
+    <p><%= t("guest_information.form.description") %></p>
+    <div id="guest-information-form-result">
+      <% if flash[:notice] %>
+        <div class="callout success"><%= flash[:notice] %></div>
+      <% elsif flash[:alert] %>
+        <div class="callout alert"><%= flash[:alert] %></div>
+      <% end %>
+    </div>
+    <%= form_for guest_information, remote: true do |f| %>
+      <%= f.text_field :name %>
+      <%= f.email_field :email %>
+      <%= f.submit(t("guest_information.form.submit_button"), class: "button") %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/custom/guest_information/form_component.rb
+++ b/app/components/custom/guest_information/form_component.rb
@@ -1,0 +1,11 @@
+class GuestInformation::FormComponent < ApplicationComponent
+  delegate :current_user, to: :helpers
+
+  def guest_information
+    return current_user.guest_information if current_user.guest_information
+
+    current_user.build_guest_information
+    current_user.guest_information.save!(validate: false)
+    current_user.guest_information
+  end
+end

--- a/app/components/custom/guest_information/scroll_to_form_component.html.erb
+++ b/app/components/custom/guest_information/scroll_to_form_component.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row scroll-to-form">
   <div class="small-12 column">
     <div class="float-right">
       <%= link_to "#guest-information-form", class: "button hollow" do %>

--- a/app/components/custom/guest_information/scroll_to_form_component.html.erb
+++ b/app/components/custom/guest_information/scroll_to_form_component.html.erb
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="small-12 column">
+    <div class="float-right">
+      <%= link_to "#guest-information-form", class: "button hollow" do %>
+        <sub><span class="icon-user"></span></sub>&nbsp;
+        <%= t("guest_information.title") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/custom/guest_information/scroll_to_form_component.rb
+++ b/app/components/custom/guest_information/scroll_to_form_component.rb
@@ -1,0 +1,2 @@
+class GuestInformation::ScrollToFormComponent < ApplicationComponent
+end

--- a/app/controllers/custom/guest_informations_controller.rb
+++ b/app/controllers/custom/guest_informations_controller.rb
@@ -1,0 +1,36 @@
+class GuestInformationsController < ApplicationController
+  include GuestUsers
+  skip_authorization_check
+  skip_before_action :verify_authenticity_token
+
+  def update
+    @guest_information = current_user.guest_information
+
+    respond_to do |format|
+      format.html do
+        if @guest_information.update(guest_information_params)
+          flash[:notice] = t("guest_information.update.success_notice")
+        else
+          flash[:alert] = t("guest_information.update.alert_error")
+        end
+        redirect_to request.referer + "#guest-information-form"
+      end
+      format.js do
+        if @guest_information.update(guest_information_params)
+          flash.now[:notice] = t("guest_information.update.success_notice")
+        end
+        render :update
+      end
+    end
+  end
+
+  private
+
+    def guest_information_params
+      params.require(:guest_information).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:name, :email]
+    end
+end

--- a/app/controllers/custom/legislation/draft_versions_controller.rb
+++ b/app/controllers/custom/legislation/draft_versions_controller.rb
@@ -1,0 +1,5 @@
+require_dependency Rails.root.join("app", "controllers", "legislation", "draft_versions_controller").to_s
+
+class Legislation::DraftVersionsController < Legislation::BaseController
+  include GuestUsers
+end

--- a/app/models/custom/guest_information.rb
+++ b/app/models/custom/guest_information.rb
@@ -1,0 +1,5 @@
+class GuestInformation < ApplicationRecord
+  belongs_to :user
+  validates :user_id, presence: true, uniqueness: true
+  validates :email, presence: true
+end

--- a/app/models/custom/user.rb
+++ b/app/models/custom/user.rb
@@ -1,0 +1,5 @@
+require_dependency Rails.root.join("app", "models", "user").to_s
+
+class User < ApplicationRecord
+  has_one :guest_information, dependent: :destroy
+end

--- a/app/views/custom/guest_informations/update.js.erb
+++ b/app/views/custom/guest_informations/update.js.erb
@@ -1,0 +1,4 @@
+$("#guest-information-form").replaceWith("<%= j render(GuestInformation::FormComponent.new) %>");
+<% if flash.now[:notice] %>
+  $("#guest-information-form-result").html('<div class="callout success"><%= flash.now[:notice] %></div>');
+<% end %>

--- a/app/views/custom/legislation/draft_versions/show.html.erb
+++ b/app/views/custom/legislation/draft_versions/show.html.erb
@@ -41,6 +41,7 @@
     </div>
 
     <%= render "legislation/processes/help_gif" %>
+    <%= render GuestInformation::ScrollToFormComponent.new %>
 
     <div class="draft-allegation">
       <details class="calc-index">
@@ -76,7 +77,8 @@
       <% else %>
         <%= render "comments_panel", draft_version: @draft_version %>
       <% end %>
-
     </div>
   </div>
 </div>
+
+<%= render GuestInformation::FormComponent.new %>

--- a/app/views/custom/legislation/processes/_help_gif.html.erb
+++ b/app/views/custom/legislation/processes/_help_gif.html.erb
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="small-12 column">
+    <div class="float-right">
+      <button type="button" class="button hollow" data-toggle="annotator-help">
+        <sub><span class="icon-edit"></span></sub>&nbsp;
+        <%= t("annotator.help.title") %>
+      </button>
+
+      <div class="dropdown-pane" id="annotator-help" data-dropdown data-auto-focus="true">
+        <% if user_signed_in? %>
+          <%= t("annotator.help.alt") %>
+        <% else %>
+          <p>
+            <%= sanitize(t("annotator.help.text",
+                sign_in: link_to_signin, sign_up: link_to_signup)) %>
+          </p>
+        <% end %>
+
+        <%= image_tag "annotator_help.gif", alt: t("annotator.help.alt") %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/custom/legislation/processes/_help_gif.html.erb
+++ b/app/views/custom/legislation/processes/_help_gif.html.erb
@@ -7,7 +7,7 @@
       </button>
 
       <div class="dropdown-pane" id="annotator-help" data-dropdown data-auto-focus="true">
-        <% if user_signed_in? %>
+        <% if user_signed_in? || current_user.guest? %>
           <%= t("annotator.help.alt") %>
         <% else %>
           <p>

--- a/app/views/custom/polls/show.html.erb
+++ b/app/views/custom/polls/show.html.erb
@@ -14,6 +14,8 @@
 
   <%= render "poll_subnav" %>
 
+  <%= render GuestInformation::ScrollToFormComponent.new %>
+
   <div class="row margin">
     <div class="small-12 medium-9 column">
       <%= render "callout" %>
@@ -111,4 +113,5 @@
       </div>
     <% end %>
   </div>
+  <%= render GuestInformation::FormComponent.new %>
 </div>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -8,6 +8,11 @@ en:
       framework:
         link: "Visit the Pro-Ethics framework pro-ethics.eu"
         logo: "Pro-Ethics logo"
+  guest_information:
+    form:
+      description: "You can enter your name and email address if you want us to send you news and results."
+      submit_button: "Update"
+      title: "Want to stay updated?"
   polls:
     answers:
       create:

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -9,10 +9,15 @@ en:
         link: "Visit the Pro-Ethics framework pro-ethics.eu"
         logo: "Pro-Ethics logo"
   guest_information:
+    title: "Do you want to receive updates?"
     form:
       description: "You can enter your name and email address if you want us to send you news and results."
       submit_button: "Update"
       title: "Want to stay updated?"
+    update:
+      success_notice: "Your contact data was saved successfully!"
+      alert_error: "The email cannot be blank"
+
   polls:
     answers:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   draw :direct_upload
   draw :document
   draw :graphql
+  draw :guest_information
   draw :legislation
   draw :management
   draw :moderation

--- a/config/routes/guest_information.rb
+++ b/config/routes/guest_information.rb
@@ -1,0 +1,1 @@
+resources :guest_informations, only: :update

--- a/db/migrate/20221123104558_create_guest_informations.rb
+++ b/db/migrate/20221123104558_create_guest_informations.rb
@@ -1,0 +1,11 @@
+class CreateGuestInformations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :guest_informations do |t|
+      t.string :email
+      t.string :name
+      t.belongs_to :user, foreign_key: true, index: { unique: true }
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_27_095739) do
+ActiveRecord::Schema.define(version: 2022_11_23_104558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -639,6 +639,13 @@ ActiveRecord::Schema.define(version: 2022_05_27_095739) do
     t.integer "poll_id"
     t.index ["geozone_id"], name: "index_geozones_polls_on_geozone_id"
     t.index ["poll_id"], name: "index_geozones_polls_on_poll_id"
+  end
+
+  create_table "guest_informations", force: :cascade do |t|
+    t.string "email"
+    t.string "name"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_guest_informations_on_user_id", unique: true
   end
 
   create_table "i18n_content_translations", id: :serial, force: :cascade do |t|
@@ -1772,6 +1779,7 @@ ActiveRecord::Schema.define(version: 2022_05_27_095739) do
   add_foreign_key "follows", "users"
   add_foreign_key "geozones_polls", "geozones"
   add_foreign_key "geozones_polls", "polls"
+  add_foreign_key "guest_informations", "users"
   add_foreign_key "identities", "users"
   add_foreign_key "images", "users"
   add_foreign_key "legislation_draft_versions", "legislation_processes"

--- a/spec/components/custom/guest_information/form_component_spec.rb
+++ b/spec/components/custom/guest_information/form_component_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe GuestInformation::FormComponent do
+  let(:guest) { create(:guest) }
+  let(:component) { GuestInformation::FormComponent.new }
+
+  before { sign_in(guest) }
+
+  it "renders guest information form" do
+    render_inline component
+
+    expect(page).to have_css "#guest-information-form"
+    expect(page).to have_field "Name"
+    expect(page).to have_field "Email"
+    expect(page).to have_button "Update"
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -117,6 +117,12 @@ FactoryBot.define do
     to_create           { |instance| instance.save(validate: false) }
   end
 
+  factory :guest_information do
+    sequence(:name)  { |n| "Guest #{n}" }
+    sequence(:email) { |n| "guest#{n}@consul.dev" }
+    user
+  end
+
   factory :poll_officer, class: "Poll::Officer" do
     user { association(:user, username: name) }
 

--- a/spec/models/custom/guest_information_spec.rb
+++ b/spec/models/custom/guest_information_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe GuestInformation do
+  let(:guest_information) { build(:guest_information) }
+
+  it "is valid" do
+    expect(guest_information).to be_valid
+  end
+
+  it "is valid without name" do
+    guest_information.name = nil
+    expect(guest_information).to be_valid
+  end
+
+  it "is invalid without email" do
+    guest_information.email = nil
+    expect(guest_information).not_to be_valid
+  end
+
+  it "is not valid without a user" do
+    guest_information.user = nil
+    expect(guest_information).not_to be_valid
+  end
+
+  it "is not valid for the same user" do
+    guest_information.save!
+    new_guest_information = build(:guest_information, user: guest_information.user)
+    expect(new_guest_information).not_to be_valid
+    expect(new_guest_information.errors.full_messages).to include("User has already been taken")
+  end
+end

--- a/spec/system/custom/guest_informations_spec.rb
+++ b/spec/system/custom/guest_informations_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Guest informations" do
+  describe "From legislation draft versions page" do
+    let(:draft_version) { create(:legislation_draft_version, :published) }
+
+    scenario "Show success notice when contact data is persisted" do
+      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+
+      fill_in "Name", with: "Tom Cruise"
+      fill_in "Email", with: "tom@cruise.com"
+      click_button "Update"
+
+      expect(page).to have_content "Your contact data was saved successfully!"
+      expect(page).to have_field "Email", with: "tom@cruise.com"
+      expect(page).to have_field "Name", with: "Tom Cruise"
+    end
+
+    scenario "Shows errors when there is validation errors" do
+      visit legislation_process_draft_version_path(draft_version.process, draft_version)
+
+      fill_in "Name", with: "Tom Cruise"
+      click_button "Update"
+
+      expect(page).to have_content "can't be blank"
+    end
+  end
+end

--- a/spec/system/custom/guest_informations_spec.rb
+++ b/spec/system/custom/guest_informations_spec.rb
@@ -25,4 +25,29 @@ describe "Guest informations" do
       expect(page).to have_content "can't be blank"
     end
   end
+
+  describe "From poll page" do
+    let(:poll) { create(:poll) }
+
+    scenario "Show success notice when contact data is persisted" do
+      visit poll_path(poll)
+
+      fill_in "Name", with: "Tom Cruise"
+      fill_in "Email", with: "tom@cruise.com"
+      click_button "Update"
+
+      expect(page).to have_content "Your contact data was saved successfully!"
+      expect(page).to have_field "Email", with: "tom@cruise.com"
+      expect(page).to have_field "Name", with: "Tom Cruise"
+    end
+
+    scenario "Shows errors when there is validation errors" do
+      visit poll_path(poll)
+
+      fill_in "Name", with: "Tom Cruise"
+      click_button "Update"
+
+      expect(page).to have_content "can't be blank"
+    end
+  end
 end

--- a/spec/system/custom/legislation/draft_versions_spec.rb
+++ b/spec/system/custom/legislation/draft_versions_spec.rb
@@ -59,4 +59,22 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content "1 vote"
     end
   end
+
+  context "See draft text page" do
+    let(:process) { create(:legislation_process) }
+
+    let!(:original) do
+      create(:legislation_draft_version, process: process, title: "Original",
+                                         body: "Original version", status: "published")
+    end
+
+    scenario "show help gif" do
+      visit legislation_process_draft_version_path(process, original)
+
+      click_button text: "How can I comment this document?"
+
+      expect(page).to have_content "Select the text you want to comment and press the button with the pencil"
+      expect(page).not_to have_content "To comment this document you must sign_in or sign_up."
+    end
+  end
 end

--- a/spec/system/legislation/draft_versions_spec.rb
+++ b/spec/system/legislation/draft_versions_spec.rb
@@ -83,7 +83,7 @@ describe "Legislation Draft Versions" do
       expect(page).to have_content "Text for additional info of the process"
     end
 
-    scenario "show help gif" do
+    scenario "show help gif", :consul do
       visit legislation_process_draft_version_path(process, original)
 
       click_button text: "How can I comment this document?"


### PR DESCRIPTION
## Objectives

* Allow guest users to give their contact information. 
* Fulfilling the form is not mandatory nor required to answer polls and participate in the legislation process.
* The information submitted by the user is never shown on any public page.

**I guess the "Legal terms and conditions" should refer to this form and specify the purpose and the usage limits of this information when given by the user.**

## Visual Changes

**Button that jumps to the form to give their name and email address**
<img width="1241" alt="Captura de Pantalla 2022-11-28 a las 16 25 06" src="https://user-images.githubusercontent.com/15726/204316065-f43d5b14-03de-406a-92cb-933d834561af.png">

**Form at the legislation draft version page**
<img width="1244" alt="Captura de Pantalla 2022-11-28 a las 16 25 15" src="https://user-images.githubusercontent.com/15726/204316089-8b943b04-f144-45e5-8396-b0900e774cf6.png">

**Form at the poll page**
<img width="1245" alt="Captura de Pantalla 2022-11-28 a las 16 26 23" src="https://user-images.githubusercontent.com/15726/204316092-571c4b08-ba90-44c4-8301-151353424e9e.png">
