### PR TITLE
Use the latest available Ubuntu image to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
       postgres:
@@ -60,7 +60,7 @@ jobs:
           name: screenshots
           path: tmp/screenshots
   coveralls:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     env:
       CI_BUILD_NUMBER: ${{ github.run_number }}


### PR DESCRIPTION
It is the Ubuntu 20.04 version at the time of writing.

GitHub Actions has deprecated the 18.04 we were using.

# References

Port from: 
* consul/consul/commit/33d288f2300b85704321744827a2a3b6ac8041e3