### PR TITLE
Use a lighter shade of grey for poll header and information sections

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -85,13 +85,14 @@ body:not(.admin) {
   }
 }
 
-.footer,
 .polls-show-header,
 .poll-more-info {
-  background: #d2dce1;
+  background: $brand-secondary;
 }
 
 .footer {
+  background: #d2dce1;
+
   .logo img {
     @include breakpoint(small only) {
       height: 1.5rem;


### PR DESCRIPTION
## References

This PR depends on the following:

* #11 

## Objectives

Use a lighter shade of grey for the poll header and information sections to improve readability because of the contrast between the text and background.

## Visual Changes

**Before**
<img width="1240" alt="Captura de pantalla 2023-01-07 a las 10 33 43" src="https://user-images.githubusercontent.com/15726/211143936-e1a5b0e8-9063-4a38-a729-c7392879f284.png">

**After**
<img width="1221" alt="Captura de pantalla 2023-01-07 a las 10 37 21" src="https://user-images.githubusercontent.com/15726/211144073-323b53e9-f016-460e-980a-ea11a876074d.png">
