### PR TITLE
Do not submit the form when the user hits the `Enter` key when writing an answer

### DIFF
--- a/app/components/custom/poll/answers/fields_component.html.erb
+++ b/app/components/custom/poll/answers/fields_component.html.erb
@@ -15,9 +15,10 @@
         <%= errors_for :answer_id %>
       </fieldset>
     <% else %>
-      <%= answer_form.text_field :open_answer, label: question.title,
-                                               hint: question.description,
-                                               disabled: cannot?(:answer, question.poll) %>
+      <%= answer_form.text_area :open_answer, label: question.title,
+                                              rows: 4,
+                                              hint: question.description,
+                                              disabled: cannot?(:answer, question.poll) %>
     <% end %>
   <% end %>
 </div>

--- a/spec/system/custom/polls/polls_spec.rb
+++ b/spec/system/custom/polls/polls_spec.rb
@@ -249,6 +249,16 @@ describe "Polls" do
       expect(page).to have_content("Poll saved successfully!")
     end
 
+    scenario "Does not submit the form when a user hits the enter key while writing an answer" do
+      create(:poll_question, poll: poll, title: "Open question")
+      visit poll_path(poll)
+
+      field = find_field("Open question")
+      field.native.send_keys(:return)
+
+      expect(page).not_to have_content("1 error prevented your answers from being saved")
+    end
+
     describe "Show validator errors" do
       scenario "for postal_code_validator" do
         poll = create(:poll)


### PR DESCRIPTION
## References

Depends on:
* #13 

## Objectives

Do not submit the form when the user hits the `Enter` key when writing an answer.

It's very discouraging for users to accidentally submit all the poll answers form when hitting the Enter keyboard while writing an open answer. This is the default behavior of text inputs, so instead, we use a text area, which allows new lines, also making it easier for users to introduce long answers to open questions.

We are using 4 rows by default.

# Screenshots
**Before**

<img width="878" alt="Captura de pantalla 2023-01-07 a las 12 21 05" src="https://user-images.githubusercontent.com/15726/211147615-3b1e50da-0859-4f8e-ad3d-d34907bc9f1d.png">


**After**
<img width="879" alt="Captura de pantalla 2023-01-07 a las 12 20 05" src="https://user-images.githubusercontent.com/15726/211147583-6809371f-3fc9-4802-83ce-cab3e5a92c1b.png">

